### PR TITLE
DTSPO-23130: Bumping chart-function version to test new release

### DIFF
--- a/charts/recipe-receiver/Chart.yaml
+++ b/charts/recipe-receiver/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.3.0
 appVersion: "0.1.0"
 dependencies:
   - name: function
-    version: 2.5.3
+    version: 2.6.0-alpha
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo'


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description

- Changing chart-function version to 2.6.0-alpha to test new release.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
